### PR TITLE
use item id if filename is empty on blobs

### DIFF
--- a/src/collective/transmute/_types.py
+++ b/src/collective/transmute/_types.py
@@ -38,7 +38,7 @@ class MetadataInfo:
     relations: dict = field(default_factory=dict)
 
 
-PloneItem = TypedDict("PloneItem", {"@id": str, "@type": str, "UID": str})
+PloneItem = TypedDict("PloneItem", {"@id": str, "@type": str, "UID": str, "id": str})
 
 PloneItemGenerator = AsyncGenerator[PloneItem | None]
 

--- a/src/collective/transmute/utils/files.py
+++ b/src/collective/transmute/utils/files.py
@@ -85,7 +85,7 @@ async def export_blob(field: str, blob: dict, content_path: Path, item_id: str) 
     return blob
 
 
-async def export_item(item: dict, parent_folder: Path) -> t.ItemFiles:
+async def export_item(item: t.PloneItem, parent_folder: Path) -> t.ItemFiles:
     """Given an item, write to the final destination."""
     # Return blobs created here
     blob_files = []


### PR DESCRIPTION
fix for #4 

potential further enhancement would be to check if file identifier is present in id and if not, try to add it from the "content-type" field.

