### PR TITLE
Include source file path and review state in per-type CSV reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ transmute.toml
 transmute.log
 # Virtual environments
 .venv
+
+# Local Claude context (not for sharing)
+.claude/*.local.*

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,29 @@ test-coverage: $(BIN_FOLDER)/pytest ## run tests
 	@uv run pytest --cov=collective.transmute --cov-report term-missing
 
 ############################################
+# Documentation
+############################################
+.PHONY: docs-html
+docs-html: $(VENV_FOLDER) ## Build HTML documentation
+	@make -C ./docs html
+
+.PHONY: docs-livehtml
+docs-livehtml: $(VENV_FOLDER) ## Build documentation and serve it
+	@make -C ./docs livehtml
+
+.PHONY: docs-vale
+docs-vale: $(VENV_FOLDER) ## Run vale on the documentation
+	@make -C ./docs vale
+
+.PHONY: docs-linkcheckbroken
+docs-linkcheckbroken: $(VENV_FOLDER) ## Run checks for broken links
+	@make -C ./docs linkcheckbroken
+
+.PHONY: docs-test
+docs-test: $(VENV_FOLDER) ## Run tests on the documentation
+	@make -C ./docs test
+
+############################################
 # Release
 ############################################
 .PHONY: changelog

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,7 +35,6 @@ help:  # This help message
 .PHONY: install
 install:  .venv/bin/python ## Sync package requirements
 
-
 .PHONY: init
 init: clean clean-python .venv/bin/python  ## Clean docs build directory and Python, and initialize Python virtual environment
 

--- a/docs/docs/how-to-guides/cli.md
+++ b/docs/docs/how-to-guides/cli.md
@@ -137,11 +137,37 @@ uv run transmute report --help
 ╰───────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-The following command will generate a report of all portal types in the `src` directory and save it to {file}`reports/report-raw-data.json`.
+The following command will generate a report of all content items in the `src` directory and save it to {file}`reports/report-raw-data.json`.
 
 ```shell
 uv run transmute report /exported-data/ reports/
 ```
+
+To generate per-type CSV reports, use the `--report-types` option with a comma-separated list of portal types.
+
+```shell
+uv run transmute report --report-types "Document,Folder" /exported-data/ reports/
+```
+
+This generates one CSV file per type (for example, {file}`report_Document.csv` and {file}`report_Folder.csv`) with the following columns.
+
+`source_file`
+: Path to the source JSON file containing the content item.
+
+`@id`
+: The original URL of the content item.
+
+`UID`
+: The unique identifier of the content item.
+
+`@type`
+: The portal type of the content item.
+
+`title`
+: The title of the content item.
+
+`review_state`
+: The workflow review state of the content item.
 
 
 ### `settings`

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -175,6 +175,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "collective-html2blocks" },
     { name = "dynaconf" },
+    { name = "getchlib" },
     { name = "orjson" },
     { name = "tomlkit" },
     { name = "typer" },
@@ -185,6 +186,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "collective-html2blocks", specifier = ">=1.0.0a3" },
     { name = "dynaconf", specifier = ">=3.2.7" },
+    { name = "getchlib", specifier = ">=1.1.3" },
     { name = "orjson", specifier = ">=3.10.15" },
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "typer", specifier = ">=0.15.1" },
@@ -374,6 +376,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/2e/3b6e5016affc310e5109bc580f760586eabecea0c8a7ab067611cd849ac0/fastapi_cloud_cli-0.1.5.tar.gz", hash = "sha256:341ee585eb731a6d3c3656cb91ad38e5f39809bf1a16d41de1333e38635a7937", size = 22710, upload-time = "2025-07-28T13:30:48.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/a6/5aa862489a2918a096166fd98d9fe86b7fd53c607678b3fa9d8c432d88d5/fastapi_cloud_cli-0.1.5-py3-none-any.whl", hash = "sha256:d80525fb9c0e8af122370891f9fa83cf5d496e4ad47a8dd26c0496a6c85a012a", size = 18992, upload-time = "2025-07-28T13:30:47.427Z" },
+]
+
+[[package]]
+name = "getchlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/2f/98dfe0d42313ddec9e03178ffbc9cc28c3bef83894c245bc2337b1d4be75/getchlib-2.0.0.tar.gz", hash = "sha256:216aa851d3056050edce3e13149b1e3b7346a036e38e640cf50de631296ca04a", size = 14537, upload-time = "2026-04-07T12:33:18.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/62/a995147984f430ed9f1e3c7af1645d4c2274a41cd3dfc43393f0e92fa3e8/getchlib-2.0.0-py3-none-any.whl", hash = "sha256:06057bebb3063e9ffc9f465dbaba5ca402703ad4ce3caa555db4a27b2b574fd5", size = 15360, upload-time = "2026-04-07T12:33:17.177Z" },
 ]
 
 [[package]]

--- a/news/58.feature
+++ b/news/58.feature
@@ -1,0 +1,1 @@
+Include source file path and review state in per-type CSV reports. @ericof

--- a/src/collective/transmute/commands/report.py
+++ b/src/collective/transmute/commands/report.py
@@ -33,20 +33,31 @@ def _create_state(
     )
 
 
+async def _write_type_report(dst: Path, type_: str, state: t.ReportState) -> Path:
+    """Write a CSV report for a specific content type."""
+    headers = ["source_file", "@id", "UID", "@type", "title", "review_state"]
+    report_path = Path(dst / f"report_{type_}.csv").resolve()
+    type_data = state.type_report.get(type_, [])
+    return await file_utils.csv_dump(type_data, headers, report_path)
+
+
 async def _create_report(dst: Path, state: t.ReportState, report_types: list) -> Path:
     logger = get_logger()
-    async for _, item in file_utils.json_reader(state.files):
+    async for source_file, item in file_utils.json_reader(state.files):
         type_ = item.get("@type")
         state.types[type_] += 1
         if type_ in report_types:
             id_ = item.get("@id")
             UID = item.get("UID")
             title = item.get("title")
+            review_state = item.get("review_state", "-") or "-"
             state.type_report[type_].append({
+                "source_file": source_file,
                 "@id": id_,
                 "UID": UID,
                 "@type": type_,
                 "title": title,
+                "review_state": review_state,
             })
         workflow_history: dict[str, list] = item.get("workflow_history", {}) or {}
         workflows = tuple(workflow_history.keys())
@@ -69,11 +80,8 @@ async def _create_report(dst: Path, state: t.ReportState, report_types: list) ->
     path = await file_utils.json_dump(data, report_path)
     logger.info(f" - Wrote report to {path}")
     if report_types:
-        headers = ["@id", "UID", "@type", "title"]
         for type_ in report_types:
-            report_path = Path(dst / f"report_{type_}.csv").resolve()
-            type_data = state.type_report.get(type_, [])
-            csv_path = await file_utils.csv_dump(type_data, headers, report_path)
+            csv_path = await _write_type_report(dst, type_, state)
             logger.info(f" - Wrote types report to {csv_path}")
     return path
 

--- a/tests/cli/test_cli_report.py
+++ b/tests/cli/test_cli_report.py
@@ -1,0 +1,108 @@
+from collective.transmute import _types as t
+from collective.transmute import layout
+from collective.transmute.commands.report import _create_report
+from collective.transmute.commands.report import _write_type_report
+
+import asyncio
+import csv
+import pytest
+
+
+@pytest.fixture
+def report_layout() -> layout.ApplicationLayout:
+    return layout.ReportLayout(title="Test Report")
+
+
+@pytest.fixture
+def report_state(report_layout, src_files) -> t.ReportState:
+    from collective.transmute.commands.report import _create_state
+
+    return _create_state(report_layout, src_files.content)
+
+
+class TestCreateReport:
+    """Tests for _create_report with type reports."""
+
+    def test_type_report_includes_source_file(self, report_state, tmp_path):
+        """Type report entries include the source_file field."""
+        report_types = ["Folder"]
+        asyncio.run(_create_report(tmp_path, report_state, report_types))
+        entries = report_state.type_report.get("Folder", [])
+        assert len(entries) > 0
+        for entry in entries:
+            assert "source_file" in entry
+            assert entry["source_file"]
+
+    def test_type_report_includes_review_state(self, report_state, tmp_path):
+        """Type report entries include the review_state field."""
+        report_types = ["Folder"]
+        asyncio.run(_create_report(tmp_path, report_state, report_types))
+        entries = report_state.type_report.get("Folder", [])
+        assert len(entries) > 0
+        for entry in entries:
+            assert "review_state" in entry
+            assert entry["review_state"]
+
+    def test_type_report_entry_keys(self, report_state, tmp_path):
+        """Type report entries have all expected keys."""
+        expected_keys = {"source_file", "@id", "UID", "@type", "title", "review_state"}
+        report_types = ["Folder"]
+        asyncio.run(_create_report(tmp_path, report_state, report_types))
+        entries = report_state.type_report.get("Folder", [])
+        assert len(entries) > 0
+        for entry in entries:
+            assert set(entry.keys()) == expected_keys
+
+
+class TestWriteTypeReport:
+    """Tests for _write_type_report CSV output."""
+
+    def test_csv_headers(self, report_state, tmp_path):
+        """CSV file has the correct headers including source_file and review_state."""
+        report_types = ["Folder"]
+        asyncio.run(_create_report(tmp_path, report_state, report_types))
+        csv_path = asyncio.run(_write_type_report(tmp_path, "Folder", report_state))
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            assert reader.fieldnames == [
+                "source_file",
+                "@id",
+                "UID",
+                "@type",
+                "title",
+                "review_state",
+            ]
+
+    def test_csv_source_file_is_first_column(self, report_state, tmp_path):
+        """source_file is the first column in the CSV."""
+        report_types = ["Folder"]
+        asyncio.run(_create_report(tmp_path, report_state, report_types))
+        csv_path = asyncio.run(_write_type_report(tmp_path, "Folder", report_state))
+        with open(csv_path) as f:
+            reader = csv.reader(f)
+            headers = next(reader)
+            assert headers[0] == "source_file"
+
+    def test_csv_rows_have_source_file_values(self, report_state, tmp_path):
+        """Each CSV row has a non-empty source_file value."""
+        report_types = ["Folder"]
+        asyncio.run(_create_report(tmp_path, report_state, report_types))
+        csv_path = asyncio.run(_write_type_report(tmp_path, "Folder", report_state))
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) > 0
+            for row in rows:
+                assert row["source_file"]
+
+    def test_csv_rows_have_review_state_values(self, report_state, tmp_path):
+        """Each CSV row has a non-empty review_state value."""
+        report_types = ["Folder"]
+        asyncio.run(_create_report(tmp_path, report_state, report_types))
+        csv_path = asyncio.run(_write_type_report(tmp_path, "Folder", report_state))
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) > 0
+            for row in rows:
+                assert row["review_state"]


### PR DESCRIPTION
## Summary

- Extracted per-type CSV writing into `_write_type_report` for clarity
- Added `source_file` (first column) and `review_state` columns to per-type CSV reports generated by `transmute report --report-types`
- Added tests for the new fields and CSV output
- Documented the `--report-types` option and its CSV columns in the CLI guide

Closes #58

## Test plan

- [x] Run `make test` — all 183 tests pass
- [x] Run `make lint` — no errors
- [x] Run `make docs-html` and `make docs-vale` — docs build cleanly
- [x] Run `transmute report --report-types "Document" /exported-data/ reports/` and verify the CSV includes `source_file` as the first column and `review_state` as the last