### PR TITLE
Add create_step guide and configuration reference documentation

### DIFF
--- a/docs/docs/how-to-guides/create_step.md
+++ b/docs/docs/how-to-guides/create_step.md
@@ -1,12 +1,296 @@
 ---
 myst:
   html_meta:
-    "description": "Create a new pipeline step in collective.transmute"
-    "property=og:description": "Create a new pipeline step in collective.transmute"
-    "property=og:title": "Create a new pipeline step in collective.transmute"
-    "keywords": "Plone, collective.transmute, create, pipeline, step, guides"
+    "description": "How to create a custom pipeline step for collective.transmute"
+    "property=og:description": "Learn how to write, register, and test custom pipeline steps for collective.transmute."
+    "property=og:title": "Create a Pipeline Step | collective.transmute"
+    "keywords": "Plone, collective.transmute, create, pipeline, step, guides, async, generator"
 ---
 
-# Create pipeline step
+# Create a pipeline step
 
-If you want, in your package, to create a new pipeline step...
+This guide explains how to create a custom pipeline step for {term}`collective.transmute`.
+Pipeline steps are the building blocks of the transformation process.
+Each step receives a content item, optionally transforms it, and yields the result.
+
+
+## Step function signature
+
+Every pipeline step must be an async generator function with the following signature.
+
+```python
+from collective.transmute import _types as t
+
+
+async def my_step(
+    item: t.PloneItem,
+    state: t.PipelineState,
+    settings: t.TransmuteSettings,
+) -> t.PloneItemGenerator:
+    """Process an item in the pipeline."""
+    # Transform the item
+    yield item
+```
+
+The three parameters are always the same.
+
+`item`
+: The content item being processed, as a `PloneItem` dictionary.
+
+`state`
+: The pipeline state object, which holds progress counters, UID mappings, metadata, and annotations shared across all steps.
+
+`settings`
+: The transmute settings loaded from {file}`transmute.toml` and defaults.
+
+
+## Yielding items
+
+A step communicates its result by yielding.
+
+### Keep the item
+
+Yield the item (modified or not) to pass it to the next step.
+
+```python
+async def normalize_title(
+    item: t.PloneItem,
+    state: t.PipelineState,
+    settings: t.TransmuteSettings,
+) -> t.PloneItemGenerator:
+    """Normalize the title to title case."""
+    title = item.get("title", "")
+    if title:
+        item["title"] = title.strip().title()
+    yield item
+```
+
+### Drop the item
+
+Yield `None` to remove the item from the pipeline.
+The item will be recorded as "dropped" in the report, with the step name noted.
+
+```python
+async def drop_expired(
+    item: t.PloneItem,
+    state: t.PipelineState,
+    settings: t.TransmuteSettings,
+) -> t.PloneItemGenerator:
+    """Drop items that have an expiration date in the past."""
+    expires = item.get("expires")
+    if expires and expires < "2025-01-01T00:00:00":
+        yield None
+    else:
+        yield item
+```
+
+### Yield multiple items
+
+A step can yield more than one item.
+This is useful when a single source item needs to be split into multiple destination items.
+The pipeline will process each yielded item independently.
+
+```{note}
+When a step yields additional items beyond the first, they are counted as new items and increase the total item count in progress tracking.
+```
+
+```python
+async def split_image(
+    item: t.PloneItem,
+    state: t.PipelineState,
+    settings: t.TransmuteSettings,
+) -> t.PloneItemGenerator:
+    """Extract an image from an item and yield it as a separate Image item."""
+    image_data = item.get("image")
+    if isinstance(image_data, dict):
+        # Create a new Image item
+        new_image = {
+            "@id": f"{item['@id']}/image",
+            "@type": "Image",
+            "UID": "some-generated-uid",
+            "id": "image",
+            "title": item.get("title", ""),
+            "image": image_data,
+            "_is_new_item": True,
+        }
+        # Remove image from original item
+        item.pop("image", None)
+        # Yield the new item first, then the modified original
+        yield new_image
+        yield item
+    else:
+        yield item
+```
+
+
+## Reading configuration
+
+Steps can read their own configuration from {file}`transmute.toml` via the `settings` parameter.
+
+For example, given this configuration:
+
+```toml
+[steps.my_step]
+threshold = 100
+excluded_types = ["File", "Image"]
+```
+
+Access it in the step:
+
+```python
+async def my_step(
+    item: t.PloneItem,
+    state: t.PipelineState,
+    settings: t.TransmuteSettings,
+) -> t.PloneItemGenerator:
+    step_config = settings.steps.get("my_step", {})
+    threshold = step_config.get("threshold", 50)
+    excluded = step_config.get("excluded_types", [])
+    if item["@type"] in excluded:
+        yield None
+    else:
+        yield item
+```
+
+
+## Using pipeline state
+
+The `state` object provides shared context across all steps.
+
+`state.metadata`
+: The `MetadataInfo` object with relations, redirects, local roles, and other metadata collected during the prepare phase.
+
+`state.uids`
+: A dictionary mapping old UIDs to new UIDs.
+
+`state.uid_path`
+: A dictionary mapping UIDs to their destination paths.
+
+`state.annotations`
+: A dictionary for steps to share data with each other.
+
+```python
+async def track_languages(
+    item: t.PloneItem,
+    state: t.PipelineState,
+    settings: t.TransmuteSettings,
+) -> t.PloneItemGenerator:
+    """Track which languages are used across all items."""
+    languages = state.annotations.setdefault("languages", set())
+    lang = item.get("language", "")
+    if lang:
+        languages.add(lang)
+    yield item
+```
+
+
+## Registering a step
+
+To add your step to the pipeline, add its dotted Python path to the `pipeline.steps` list in {file}`transmute.toml`.
+
+```toml
+[pipeline]
+steps = [
+    "collective.transmute.steps.ids.process_export_prefix",
+    "collective.transmute.steps.ids.process_ids",
+    # ... other steps ...
+    "my_package.steps.normalize_title",  # Your custom step
+    "collective.transmute.steps.sanitize.process_cleanup",
+]
+```
+
+```{important}
+Step order matters.
+Steps run sequentially from top to bottom.
+Each step receives the item as modified by previous steps.
+Place your step in the position that makes sense for your transformation logic.
+```
+
+
+### The `do_not_add_drop` setting
+
+By default, the pipeline wraps each step so that if the step yields `None`, the item is recorded as "dropped" and removed from the pipeline.
+Some steps need to yield `None` temporarily (for example, to defer processing) without marking the item as dropped.
+
+If your step yields `None` for reasons other than dropping, add its function name to the `do_not_add_drop` list.
+
+```toml
+[pipeline]
+do_not_add_drop = ["process_paths", "process_default_page", "my_deferred_step"]
+```
+
+
+## Testing a step
+
+The project provides fixtures that make testing steps straightforward.
+Tests are async and use `pytest` with `pytest-asyncio`.
+
+```python
+import pytest
+
+
+@pytest.mark.parametrize(
+    "base_item,expected_title",
+    [
+        [{"@id": "/foo", "@type": "Document", "UID": "abc", "id": "foo", "title": "hello world"}, "Hello World"],
+        [{"@id": "/bar", "@type": "Document", "UID": "def", "id": "bar", "title": "  spaced  "}, "Spaced"],
+    ],
+)
+async def test_normalize_title(
+    pipeline_state, transmute_settings, base_item, expected_title
+):
+    from my_package.steps import normalize_title
+
+    results = []
+    async for item in normalize_title(base_item, pipeline_state, transmute_settings):
+        results.append(item)
+    assert len(results) == 1
+    assert results[0]["title"] == expected_title
+```
+
+The `pipeline_state` and `transmute_settings` fixtures are provided by the test infrastructure in {file}`tests/conftest.py`.
+
+
+## Complete example
+
+The following is a complete, minimal step that filters items by a custom field read from configuration.
+
+```python
+"""Pipeline step to filter items by language."""
+from collective.transmute import _types as t
+
+
+async def filter_by_language(
+    item: t.PloneItem,
+    state: t.PipelineState,
+    settings: t.TransmuteSettings,
+) -> t.PloneItemGenerator:
+    """Drop items whose language is not in the allowed list.
+
+    Configuration in transmute.toml:
+
+        [steps.language_filter]
+        allowed = ["en", "de"]
+    """
+    step_config = settings.steps.get("language_filter", {})
+    allowed = step_config.get("allowed", [])
+    if not allowed or item.get("language", "") in allowed:
+        yield item
+    else:
+        yield None
+```
+
+Register it in {file}`transmute.toml`.
+
+```toml
+[pipeline]
+steps = [
+    "collective.transmute.steps.ids.process_export_prefix",
+    "collective.transmute.steps.ids.process_ids",
+    "my_package.steps.filter_by_language",
+    # ... remaining steps ...
+]
+
+[steps.language_filter]
+allowed = ["en", "de"]
+```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -59,6 +59,7 @@ how-to-guides/create_step
 :maxdepth: 2
 :hidden: true
 
+reference/configuration
 reference/api
 ```
 

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -268,6 +268,16 @@ allowed = ["published"]
   An empty list allows all states.
   Default: `["published"]`
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.review_state`
+  - `process_review_state()`
+```
+
 ### `[review_state.rewrite]`
 
 ```toml
@@ -286,17 +296,12 @@ workflows = {}
 
 ```{list-table} Used by
 :header-rows: 1
-:widths: 50 30 20
+:widths: 60 40
 
 * - Module
   - Function
-  - Keys
-* - {py:mod}`collective.transmute.steps.review_state`
-  - `process_review_state()`
-  - `filter.allowed`
 * - {py:mod}`collective.transmute.utils.workflow`
   - `rewrite_workflow_history()`
-  - `rewrite.states`, `rewrite.workflows`
 ```
 
 
@@ -314,6 +319,16 @@ export_prefixes = ["http://localhost:8080/Plone"]
   These are the base URLs of the source Plone site.
   Default: `["http://localhost:8080/Plone"]`
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.ids`
+  - `process_export_prefix()`
+```
+
 ### `[paths.cleanup]`
 
 Mapping of path substrings to their replacements.
@@ -324,6 +339,16 @@ Mapping of path substrings to their replacements.
 ```
 
 Each key is a substring to find in item paths, and the value is its replacement.
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.ids`
+  - `process_ids()`
+```
 
 ### `[paths.filter]`
 
@@ -342,6 +367,16 @@ drop = []
 : List of path prefixes to exclude. Items under these prefixes are dropped.
   Default: `[]`
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.paths`
+  - `process_paths()`
+```
+
 ### `[paths.portal_type]`
 
 Mapping of path prefixes to portal type overrides.
@@ -354,23 +389,12 @@ Items under a given path prefix will have their portal type changed.
 
 ```{list-table} Used by
 :header-rows: 1
-:widths: 50 30 20
+:widths: 60 40
 
 * - Module
   - Function
-  - Keys
-* - {py:mod}`collective.transmute.steps.ids`
-  - `process_export_prefix()`
-  - `export_prefixes`
-* - {py:mod}`collective.transmute.steps.ids`
-  - `process_ids()`
-  - `cleanup`
-* - {py:mod}`collective.transmute.steps.paths`
-  - `process_paths()`
-  - `filter.allowed`, `filter.drop`
 * - {py:mod}`collective.transmute.steps.portal_type`
   - `process_type()`
-  - `portal_type`
 ```
 
 

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -55,6 +55,27 @@ report = 1000
 : Number of items processed between progress updates in the log.
   Default: `1000`
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.settings`
+  - `logger_settings()`
+  - `log_file`
+* - {py:mod}`collective.transmute.reports`
+  - `get_reports_location()`
+  - `reports_location`
+* - {py:mod}`collective.transmute.commands.report`
+  - `report()`
+  - `reports_location`
+* - {py:mod}`collective.transmute.reports.final_state`
+  - `report_final_state()`
+  - `debug`
+```
+
 
 ## `[pipeline]`
 
@@ -109,6 +130,30 @@ do_not_add_drop = ["process_paths", "process_default_page"]
   Use this for steps that yield `None` for reasons other than dropping an item.
   Default: `["process_paths", "process_default_page"]`
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.pipeline`
+  - `all_steps()`
+  - `steps`
+* - {py:mod}`collective.transmute.pipeline.prepare`
+  - `prepare_pipeline()`
+  - `prepare_steps`
+* - {py:mod}`collective.transmute.pipeline.report`
+  - `final_reports()`
+  - `report_steps`
+* - {py:mod}`collective.transmute.pipeline.pipeline`
+  - `run_step()`
+  - `do_not_add_drop`
+* - {py:mod}`collective.transmute.commands.sanity`
+  - `sanity()`
+  - `steps`
+```
+
 
 ## `[site_root]`
 
@@ -127,6 +172,21 @@ dest = "/Plone"
 `dest`
 : The site root path in the destination portal.
   Default: `"/Plone"`
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.pipeline`
+  - `pipeline()`
+  - `dest`
+* - {py:mod}`collective.transmute.steps.portal_type.collection`
+  - `_src_site_root()`
+  - `src`
+```
 
 
 ## `[principals]`
@@ -147,6 +207,18 @@ remove = ["admin"]
 : List of creator usernames to remove from content items.
   Default: `["admin"]`
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.creators`
+  - `process_creators()`
+  - `remove`, `default`
+```
+
 
 ## `[default_pages]`
 
@@ -166,6 +238,18 @@ keys_from_parent = ["@id", "id"]
 `keys_from_parent`
 : List of keys to copy from the parent item when merging a default page.
   Default: `["@id", "id"]`
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.default_page`
+  - `process_default_page()`
+  - `keep`, `keys_from_parent`
+```
 
 
 ## `[review_state]`
@@ -199,6 +283,21 @@ workflows = {}
 `workflows`
 : Mapping of source workflow IDs to destination workflow IDs.
   Default: `{}`
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.review_state`
+  - `process_review_state()`
+  - `filter.allowed`
+* - {py:mod}`collective.transmute.utils.workflow`
+  - `rewrite_workflow_history()`
+  - `rewrite.states`, `rewrite.workflows`
+```
 
 
 ## `[paths]`
@@ -253,6 +352,28 @@ Items under a given path prefix will have their portal type changed.
 "/news" = "News Item"
 ```
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.ids`
+  - `process_export_prefix()`
+  - `export_prefixes`
+* - {py:mod}`collective.transmute.steps.ids`
+  - `process_ids()`
+  - `cleanup`
+* - {py:mod}`collective.transmute.steps.paths`
+  - `process_paths()`
+  - `filter.allowed`, `filter.drop`
+* - {py:mod}`collective.transmute.steps.portal_type`
+  - `process_type()`
+  - `portal_type`
+```
+
+
 ## `[images]`
 
 Controls image-to-preview-image conversion.
@@ -265,6 +386,18 @@ to_preview_image_link = []
 `to_preview_image_link`
 : List of portal types whose `image` field should be extracted into a separate Image item with a `preview_image_link` relation.
   Default: `[]`
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.image`
+  - `process_image_to_preview_image_link()`
+  - `to_preview_image_link`
+```
 
 
 ## `[sanitize]`
@@ -302,6 +435,18 @@ block_keys = [
 : List of additional keys to remove from items that have Volto blocks.
   These keys are typically remnants of the classic Plone content model and are no longer needed once the content has been converted to blocks.
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.sanitize`
+  - `process_cleanup()`
+  - `drop_keys`, `block_keys`
+```
+
 
 ## `[data_override]`
 
@@ -310,6 +455,18 @@ Path-based field overrides. Each key is an item path, and the value is a diction
 ```toml
 [data_override]
 "/some/specific/path" = { "title" = "New Title", "review_state" = "private" }
+```
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.data_override`
+  - `process_data_override()`
+  - Item `@id` lookup
 ```
 
 
@@ -358,6 +515,27 @@ processor = "collective.transmute.steps.portal_type.collection.processor"
 `override_blocks`
 : Alternative block list that takes precedence over `blocks` when present.
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 50 30 20
+
+* - Module
+  - Function
+  - Keys
+* - {py:mod}`collective.transmute.steps.portal_type`
+  - `process_type()`
+  - `portal_type`, `processor`
+* - {py:mod}`collective.transmute.steps.blocks`
+  - `process_blocks()`
+  - `blocks`, `override_blocks`
+* - {py:mod}`collective.transmute.steps.constraints`
+  - `process_constraints()`
+  - `portal_type`
+* - {py:mod}`collective.transmute.utils.portal_types`
+  - `fix_portal_type()`
+  - `portal_type`
+```
+
 
 ## `[steps]`
 
@@ -376,6 +554,16 @@ full_view = "summary"
 album_view = "imageGallery"
 ```
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.blocks`
+  - `process_blocks()`
+```
+
 ### `[steps.blobs]`
 
 ```toml
@@ -385,6 +573,16 @@ field_names = ["file", "image", "preview_image"]
 
 `field_names`
 : List of field names that contain blob data to be extracted as separate files.
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.blobs`
+  - `process_blobs()`
+```
 
 ### `[steps.date_filter]`
 
@@ -397,6 +595,16 @@ created = "2000-01-01T00:00:00"
 
 Each key is a date field name, and the value is the ISO 8601 date threshold.
 
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.dates`
+  - `filter_by_date()`
+```
+
 ### `[steps.paths.prefix_replacement]`
 
 Mapping of source path prefixes to destination path prefixes for path rewriting.
@@ -404,4 +612,14 @@ Mapping of source path prefixes to destination path prefixes for path rewriting.
 ```toml
 [steps.paths.prefix_replacement]
 "/old-section" = "/new-section"
+```
+
+```{list-table} Used by
+:header-rows: 1
+:widths: 60 40
+
+* - Module
+  - Function
+* - {py:mod}`collective.transmute.steps.ids`
+  - `process_ids()`
 ```

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -1,0 +1,407 @@
+---
+myst:
+  html_meta:
+    "description": "Complete reference of all transmute.toml configuration options for collective.transmute"
+    "property=og:description": "Detailed reference for every section and key in the transmute.toml configuration file."
+    "property=og:title": "Configuration Reference | collective.transmute"
+    "keywords": "Plone, collective.transmute, configuration, TOML, transmute.toml, reference, settings"
+---
+
+# Configuration reference
+
+This page documents every section and key available in the {file}`transmute.toml` configuration file.
+
+To generate an initial configuration file with defaults, run the following command.
+
+```shell
+uv run transmute settings generate
+```
+
+```{seealso}
+For an introduction to configuring migrations, see {doc}`/how-to-guides/usage`.
+```
+
+
+## `[config]`
+
+General application settings.
+
+```toml
+[config]
+debug = false
+log_file = "transmute.log"
+prepare_data_location = "."
+reports_location = "."
+report = 1000
+```
+
+`debug`
+: Enable debug mode. When `true`, additional logging is written.
+  Default: `false`
+
+`log_file`
+: Path to the log file.
+  Default: `"transmute.log"`
+
+`prepare_data_location`
+: Directory where prepared metadata files are stored during processing.
+  Default: `"."`
+
+`reports_location`
+: Directory where generated report files are saved.
+  Default: `"."`
+
+`report`
+: Number of items processed between progress updates in the log.
+  Default: `1000`
+
+
+## `[pipeline]`
+
+Controls which steps run and in what order.
+
+```toml
+[pipeline]
+prepare_steps = []
+steps = [
+    "collective.transmute.steps.ids.process_export_prefix",
+    "collective.transmute.steps.uids.drop_item_by_uid",
+    "collective.transmute.steps.dates.filter_by_date",
+    "collective.transmute.steps.ids.process_ids",
+    "collective.transmute.steps.paths.process_paths",
+    "collective.transmute.steps.portal_type.process_type",
+    "collective.transmute.steps.basic_metadata.process_title",
+    "collective.transmute.steps.basic_metadata.process_title_description",
+    "collective.transmute.steps.review_state.process_review_state",
+    "collective.transmute.steps.default_page.process_default_page",
+    "collective.transmute.steps.image.process_image_to_preview_image_link",
+    "collective.transmute.steps.data_override.process_data_override",
+    "collective.transmute.steps.creators.process_creators",
+    "collective.transmute.steps.constraints.process_constraints",
+    "collective.transmute.steps.blocks.process_blocks",
+    "collective.transmute.steps.blobs.process_blobs",
+    "collective.transmute.steps.sanitize.process_cleanup",
+]
+report_steps = [
+    "collective.transmute.reports.paths.write_paths_report",
+    "collective.transmute.reports.final_state.report_final_state",
+    "collective.transmute.reports.dropped.report_dropped_by_path_prefix",
+]
+do_not_add_drop = ["process_paths", "process_default_page"]
+```
+
+`prepare_steps`
+: List of dotted paths to functions that run before the main pipeline.
+  These steps prepare metadata (for example, redirects, local roles, and relations).
+  Default: `[]`
+
+`steps`
+: Ordered list of dotted paths to pipeline step functions.
+  Each step is an async generator that receives and yields items.
+  See {doc}`/how-to-guides/create_step` for details on writing custom steps.
+
+`report_steps`
+: List of dotted paths to functions that run after the pipeline completes.
+  These generate CSV reports and console summaries.
+
+`do_not_add_drop`
+: List of step function names (not full dotted paths) that should not be wrapped with the automatic drop-item logic.
+  Use this for steps that yield `None` for reasons other than dropping an item.
+  Default: `["process_paths", "process_default_page"]`
+
+
+## `[site_root]`
+
+Defines the source and destination site root paths, used for path rewriting and redirect generation.
+
+```toml
+[site_root]
+src = "/Plone"
+dest = "/Plone"
+```
+
+`src`
+: The site root path in the source (exported) data.
+  Default: `"/Plone"`
+
+`dest`
+: The site root path in the destination portal.
+  Default: `"/Plone"`
+
+
+## `[principals]`
+
+Controls how content creators are processed.
+
+```toml
+[principals]
+default = "Plone"
+remove = ["admin"]
+```
+
+`default`
+: The default creator to use when all original creators are removed.
+  Default: `"Plone"`
+
+`remove`
+: List of creator usernames to remove from content items.
+  Default: `["admin"]`
+
+
+## `[default_pages]`
+
+Controls how default pages (index pages) are handled during migration.
+
+```toml
+[default_pages]
+keep = false
+keys_from_parent = ["@id", "id"]
+```
+
+`keep`
+: Whether to keep default pages as separate items.
+  When `false`, the default page is merged into its parent container.
+  Default: `false`
+
+`keys_from_parent`
+: List of keys to copy from the parent item when merging a default page.
+  Default: `["@id", "id"]`
+
+
+## `[review_state]`
+
+Controls filtering and rewriting of workflow review states.
+
+### `[review_state.filter]`
+
+```toml
+[review_state.filter]
+allowed = ["published"]
+```
+
+`allowed`
+: List of review states to keep. Items in other states are dropped.
+  An empty list allows all states.
+  Default: `["published"]`
+
+### `[review_state.rewrite]`
+
+```toml
+[review_state.rewrite]
+states = {}
+workflows = {}
+```
+
+`states`
+: Mapping of source review state names to destination review state names.
+  Default: `{}`
+
+`workflows`
+: Mapping of source workflow IDs to destination workflow IDs.
+  Default: `{}`
+
+
+## `[paths]`
+
+Controls path processing, filtering, and cleanup.
+
+```toml
+[paths]
+export_prefixes = ["http://localhost:8080/Plone"]
+```
+
+`export_prefixes`
+: List of URL prefixes to strip from item `@id` values.
+  These are the base URLs of the source Plone site.
+  Default: `["http://localhost:8080/Plone"]`
+
+### `[paths.cleanup]`
+
+Mapping of path substrings to their replacements.
+
+```toml
+[paths.cleanup]
+"/_" = "/"
+```
+
+Each key is a substring to find in item paths, and the value is its replacement.
+
+### `[paths.filter]`
+
+```toml
+[paths.filter]
+allowed = []
+drop = []
+```
+
+`allowed`
+: List of path prefixes to keep. If not empty, only items under these prefixes are processed.
+  An empty list allows all paths.
+  Default: `[]`
+
+`drop`
+: List of path prefixes to exclude. Items under these prefixes are dropped.
+  Default: `[]`
+
+### `[paths.portal_type]`
+
+Mapping of path prefixes to portal type overrides.
+Items under a given path prefix will have their portal type changed.
+
+```toml
+[paths.portal_type]
+"/news" = "News Item"
+```
+
+## `[images]`
+
+Controls image-to-preview-image conversion.
+
+```toml
+[images]
+to_preview_image_link = []
+```
+
+`to_preview_image_link`
+: List of portal types whose `image` field should be extracted into a separate Image item with a `preview_image_link` relation.
+  Default: `[]`
+
+
+## `[sanitize]`
+
+Controls which fields are removed from items at the end of the pipeline.
+
+```toml
+[sanitize]
+drop_keys = [
+    "is_folderish",
+    "items",
+    "layout",
+    "limit",
+    "lock",
+    "nextPreviousEnabled",
+    "parent",
+]
+block_keys = [
+    "item_count",
+    "items_total",
+    "limit",
+    "query",
+    "sort_on",
+    "sort_reversed",
+    "text",
+    "template_layout",
+    "tiles",
+]
+```
+
+`drop_keys`
+: List of keys to remove from all items.
+
+`block_keys`
+: List of additional keys to remove from items that have Volto blocks.
+  These keys are typically remnants of the classic Plone content model and are no longer needed once the content has been converted to blocks.
+
+
+## `[data_override]`
+
+Path-based field overrides. Each key is an item path, and the value is a dictionary of fields to set on that item.
+
+```toml
+[data_override]
+"/some/specific/path" = { "title" = "New Title", "review_state" = "private" }
+```
+
+
+## `[types]`
+
+Defines portal type mappings, processors, and block configurations.
+
+### Global processor
+
+```toml
+[types]
+processor = "collective.transmute.steps.portal_type.default.processor"
+```
+
+`processor`
+: Dotted path to the default type processor function.
+  Used for types that don't define their own processor.
+
+### Per-type configuration
+
+Each portal type can have its own subsection.
+
+```toml
+[types.Document]
+portal_type = "Document"
+blocks = [{ "@type" = "title" }, { "@type" = "description" }]
+
+[types.Folder]
+portal_type = "Document"
+
+[types.Collection]
+portal_type = "Document"
+processor = "collective.transmute.steps.portal_type.collection.processor"
+```
+
+`portal_type`
+: The destination portal type. Use this to map source types to different destination types (for example, `Folder` to `Document`).
+
+`processor`
+: Dotted path to a type-specific processor function. Overrides the global processor for this type.
+
+`blocks`
+: List of default Volto blocks to add to items of this type.
+  Each block is a dictionary with at least an `@type` key.
+
+`override_blocks`
+: Alternative block list that takes precedence over `blocks` when present.
+
+
+## `[steps]`
+
+Per-step configuration. Each step can define its own subsection under `[steps]`.
+
+### `[steps.blocks.variations]`
+
+Mapping of classic Plone view names to Volto listing block variations.
+
+```toml
+[steps.blocks.variations]
+listing_view = "listing"
+summary_view = "summary"
+tabular_view = "listing"
+full_view = "summary"
+album_view = "imageGallery"
+```
+
+### `[steps.blobs]`
+
+```toml
+[steps.blobs]
+field_names = ["file", "image", "preview_image"]
+```
+
+`field_names`
+: List of field names that contain blob data to be extracted as separate files.
+
+### `[steps.date_filter]`
+
+Date thresholds for filtering items. Items with field values older than the threshold are dropped.
+
+```toml
+[steps.date_filter]
+created = "2000-01-01T00:00:00"
+```
+
+Each key is a date field name, and the value is the ISO 8601 date threshold.
+
+### `[steps.paths.prefix_replacement]`
+
+Mapping of source path prefixes to destination path prefixes for path rewriting.
+
+```toml
+[steps.paths.prefix_replacement]
+"/old-section" = "/new-section"
+```

--- a/docs/styles/config/vocabularies/Plone/accept.txt
+++ b/docs/styles/config/vocabularies/Plone/accept.txt
@@ -37,11 +37,14 @@ RichText
 Sass
 Schuko
 subfolder
+substring[s]{0,1}
+
 [Tt]owncrier
 transpile[dr]{0,1}
 [Uu]ncomment
 [Uu]nhide
 unregister
+UID(s)
 UUID
 uv
 validator

--- a/news/62.documentation
+++ b/news/62.documentation
@@ -1,0 +1,1 @@
+Completed the create_step.md guide for writing custom pipeline steps. @ericof

--- a/news/63.documentation
+++ b/news/63.documentation
@@ -1,0 +1,1 @@
+Added a configuration reference documenting all transmute.toml options. @ericof


### PR DESCRIPTION
## Summary

- Completed the `create_step.md` guide covering: step function signature, yielding items (keep/drop/multiple), reading configuration, using pipeline state, registering steps, `do_not_add_drop`, testing, and a full end-to-end example
- Added a comprehensive configuration reference (`reference/configuration.md`) documenting every `transmute.toml` section and key, including previously undocumented options (`site_root`, `prepare_data_location`, `reports_location`, `prepare_steps`, `report_steps`, `do_not_add_drop`, `types`, `steps.*`)
- Each configuration section and subsection includes a "Used by" table cross-referencing the modules and functions that read those settings
- Added configuration reference to the docs index under the Reference section

Closes #62
Closes #63

## Test plan

- [x] Run `make test` — all 183 tests pass
- [x] Run `make docs-html` — builds with no warnings
- [x] Run `make docs-vale` — only pre-existing suggestions, no errors