### PR TITLE
Fix report missing source metadata for multi-yield processor items

### DIFF
--- a/news/66.bugfix
+++ b/news/66.bugfix
@@ -1,0 +1,1 @@
+Fixed report missing source metadata for multi-yield processor items. @ericof

--- a/src/collective/transmute/pipeline/__init__.py
+++ b/src/collective/transmute/pipeline/__init__.py
@@ -116,8 +116,9 @@ def _prepare_report_items(
             >>> src, dst = _prepare_report_items(item, last_step, is_new, src_item)
     """
     _no_data_ = ITEM_PLACEHOLDER
+    report_src = dict(src_item)
     if not item:
-        return src_item, {
+        return report_src, {
             "dst_path": _no_data_,
             "dst_type": _no_data_,
             "dst_uid": _no_data_,
@@ -136,12 +137,7 @@ def _prepare_report_items(
         "dst_level": _level_from_path(item.get("@id", "")),
         "status": "processed",
     }
-    if is_new:
-        src_item["src_type"] = _no_data_
-        src_item["src_uid"] = _no_data_
-        src_item["src_state"] = _no_data_
-        src_item["src_level"] = _no_data_
-    return src_item, dst_item
+    return report_src, dst_item
 
 
 def _handle_redirects(src_item, dst_item, redirects: dict[str, str], site_root: str):
@@ -287,25 +283,27 @@ async def pipeline(
                     progress.advance("processed")
                     src_item["src_path"] = raw_item.get("_@id", src_item["src_path"])
                     src_item["src_level"] = _level_from_path(src_item["src_path"])
-                    src_item, dst_item = _prepare_report_items(
+                    report_src, dst_item = _prepare_report_items(
                         item, last_step, is_new, src_item
                     )
                     # Add a redirect if needed
-                    _handle_redirects(src_item, dst_item, redirects, site_root)
+                    _handle_redirects(report_src, dst_item, redirects, site_root)
 
                     if not item:
                         # Dropped file
                         progress.advance("dropped")
                         dropped[last_step] += 1
                         path_transforms.append(
-                            t.PipelineItemReport(**src_item, **dst_item)
+                            t.PipelineItemReport(**report_src, **dst_item)
                         )
                         continue
                     elif is_new:
                         total += 1
                         progress.total("processed", total)
 
-                    path_transforms.append(t.PipelineItemReport(**src_item, **dst_item))
+                    path_transforms.append(
+                        t.PipelineItemReport(**report_src, **dst_item)
+                    )
                     item_files = await file_utils.export_item(item, content_folder)
                     # Update metadata
                     data_file = item_files.data

--- a/tests/pipeline/test_pipeline_report_items.py
+++ b/tests/pipeline/test_pipeline_report_items.py
@@ -1,0 +1,138 @@
+from collective.transmute.pipeline import _prepare_report_items
+
+import pytest
+
+
+@pytest.fixture
+def src_item():
+    return {
+        "filename": "1745.json",
+        "src_path": "/my-folder/my-document",
+        "src_type": "Document",
+        "src_uid": "abc123",
+        "src_workflow": "simple_publication_workflow",
+        "src_state": "published",
+        "src_level": 2,
+    }
+
+
+@pytest.fixture
+def processed_item():
+    return {
+        "@id": "/my-folder/my-document",
+        "@type": "Document",
+        "UID": "abc123",
+        "id": "my-document",
+        "review_state": "published",
+        "workflow_history": {
+            "simple_publication_workflow": [],
+        },
+    }
+
+
+@pytest.fixture
+def new_child_item():
+    return {
+        "@id": "/my-folder/my-document/image",
+        "@type": "Image",
+        "UID": "def456",
+        "id": "image",
+        "review_state": "published",
+        "workflow_history": {
+            "simple_publication_workflow": [],
+        },
+        "_is_new_item": True,
+    }
+
+
+class TestPrepareReportItemsDoesNotMutateSrcItem:
+    """Ensure _prepare_report_items does not mutate the original src_item."""
+
+    def test_processed_item(self, src_item, processed_item):
+        original = dict(src_item)
+        _prepare_report_items(processed_item, "process_blocks", False, src_item)
+        assert src_item == original
+
+    def test_dropped_item(self, src_item):
+        original = dict(src_item)
+        _prepare_report_items(None, "process_paths", False, src_item)
+        assert src_item == original
+
+    def test_new_child_item(self, src_item, new_child_item):
+        original = dict(src_item)
+        _prepare_report_items(new_child_item, "process_blocks", True, src_item)
+        assert src_item == original
+
+
+class TestNewItemPreservesSourceMetadata:
+    """New (child) items should carry the parent's source metadata."""
+
+    def test_preserves_src_type(self, src_item, new_child_item):
+        report_src, _ = _prepare_report_items(
+            new_child_item, "process_blocks", True, src_item
+        )
+        assert report_src["src_type"] == "Document"
+
+    def test_preserves_src_uid(self, src_item, new_child_item):
+        report_src, _ = _prepare_report_items(
+            new_child_item, "process_blocks", True, src_item
+        )
+        assert report_src["src_uid"] == "abc123"
+
+    def test_preserves_src_state(self, src_item, new_child_item):
+        report_src, _ = _prepare_report_items(
+            new_child_item, "process_blocks", True, src_item
+        )
+        assert report_src["src_state"] == "published"
+
+    def test_preserves_src_level(self, src_item, new_child_item):
+        report_src, _ = _prepare_report_items(
+            new_child_item, "process_blocks", True, src_item
+        )
+        assert report_src["src_level"] == 2
+
+    def test_preserves_filename(self, src_item, new_child_item):
+        report_src, _ = _prepare_report_items(
+            new_child_item, "process_blocks", True, src_item
+        )
+        assert report_src["filename"] == "1745.json"
+
+    def test_preserves_src_workflow(self, src_item, new_child_item):
+        report_src, _ = _prepare_report_items(
+            new_child_item, "process_blocks", True, src_item
+        )
+        assert report_src["src_workflow"] == "simple_publication_workflow"
+
+
+class TestMultiYieldPreservesSourceMetadata:
+    """Simulates a processor yielding multiple items from one source."""
+
+    def test_second_item_has_correct_src_type(
+        self, src_item, new_child_item, processed_item
+    ):
+        """After processing a new child, the original item's src_type is intact."""
+        # First yield: the new child item
+        _prepare_report_items(new_child_item, "process_blocks", True, src_item)
+        # Second yield: the original (modified) item
+        report_src, _ = _prepare_report_items(
+            processed_item, "process_blocks", False, src_item
+        )
+        assert report_src["src_type"] == "Document"
+
+    def test_second_item_has_correct_src_uid(
+        self, src_item, new_child_item, processed_item
+    ):
+        _prepare_report_items(new_child_item, "process_blocks", True, src_item)
+        report_src, _ = _prepare_report_items(
+            processed_item, "process_blocks", False, src_item
+        )
+        assert report_src["src_uid"] == "abc123"
+
+    def test_second_item_has_correct_src_state(
+        self, src_item, new_child_item, processed_item
+    ):
+        _prepare_report_items(new_child_item, "process_blocks", True, src_item)
+        report_src, _ = _prepare_report_items(
+            processed_item, "process_blocks", False, src_item
+        )
+        assert report_src["src_state"] == "published"


### PR DESCRIPTION
## Summary

- Fixed `_prepare_report_items` mutating the shared `src_item` dict in place, which corrupted source metadata for subsequent items from the same source file
- Removed the blanking of `src_type`, `src_uid`, `src_state`, and `src_level` for new (child) items — they now preserve the parent's source metadata so the report correctly traces them back to their origin
- Added 12 tests covering non-mutation, metadata preservation for child items, and the exact multi-yield bug scenario

Closes #66

## Root cause

`_prepare_report_items` was doing two things wrong:

1. **Mutating `src_item` in place** — Since `src_item` is shared across all iterations of the `run_pipeline` loop for a given source file, modifying it for one yielded item corrupted it for subsequent items.

2. **Blanking source fields for new items** — When `is_new=True`, source metadata fields were set to `"--"`. This made it impossible to trace child items (e.g., extracted images) back to their source.

## Fix

- Return a shallow copy (`dict(src_item)`) instead of mutating the original
- Remove the `is_new` blanking logic — child items now carry their parent's source metadata

## Test plan

- [x] Run `make test` — all 195 tests pass (183 existing + 12 new)
- [x] Run `make lint` — no errors
- [x] Run `make format` — no changes needed