### PR TITLE
Support preview_image field in image-to-preview conversion

### DIFF
--- a/news/70.feature
+++ b/news/70.feature
@@ -1,0 +1,1 @@
+Added support for the `preview_image` field in the `process_image_to_preview_image_link` step, taking precedence over `image` when both are present. @ericof

--- a/src/collective/transmute/_types/plone.py
+++ b/src/collective/transmute/_types/plone.py
@@ -65,6 +65,8 @@ PloneItem = TypedDict(
         "creators": NotRequired[list[str]],
         "image": NotRequired[dict[str, str | int]],
         "image_caption": NotRequired[str],
+        "preview_image": NotRequired[dict[str, str | int]],
+        "preview_image_caption": NotRequired[str],
         "remoteUrl": NotRequired[str],
         "subjects": NotRequired[list[str]],
         "language": NotRequired[str],

--- a/src/collective/transmute/steps/image.py
+++ b/src/collective/transmute/steps/image.py
@@ -11,6 +11,9 @@ from collective.transmute import _types as t
 from collective.transmute.utils import item as utils
 
 
+IMAGE_FIELDS: tuple[str, ...] = ("image", "preview_image")
+
+
 def get_conversion_types(settings: t.TransmuteSettings) -> tuple[str, ...]:
     """
     Get content types that require ``image`` to ``preview_image_link`` conversion.
@@ -35,14 +38,46 @@ def get_conversion_types(settings: t.TransmuteSettings) -> tuple[str, ...]:
     return settings.images["to_preview_image_link"]
 
 
+def cleanup_image_fields(item: t.PloneItem) -> t.PloneItem:
+    """
+    Remove image fields from an item.
+
+    Parameters
+    ----------
+    item : PloneItem
+        The item to clean up.
+
+    Returns
+    -------
+    PloneItem
+        The cleaned-up item without image fields.
+
+    Example
+    -------
+    .. code-block:: pycon
+
+        >>> cleaned_item = cleanup_image_fields(item)
+        >>> 'image' not in cleaned_item
+        True
+        >>> 'preview_image' not in cleaned_item
+        True
+    """
+    for image_field in IMAGE_FIELDS:
+        item.pop(image_field, None)
+        item.pop(f"{image_field}_caption", None)
+    return item
+
+
 async def process_image_to_preview_image_link(
     item: t.PloneItem,
     state: t.PipelineState,
     settings: t.TransmuteSettings,
 ) -> t.PloneItemGenerator:
     """
-    Convert ``image`` field to ``preview_image_link`` and manage image relations for
-    an item.
+    Convert an ``image`` or ``preview_image`` field to a ``preview_image_link``
+    relation and manage image relations for an item.
+
+    When both fields are present, ``preview_image`` takes precedence over ``image``.
 
     Parameters
     ----------
@@ -70,15 +105,12 @@ async def process_image_to_preview_image_link(
     if type_ not in get_conversion_types(settings):
         yield item
     else:
-        image = item.get("image", None)
+        image_field = "preview_image" if "preview_image" in item else "image"
+        image = item.get(image_field, None)
         if isinstance(image, dict) and metadata:
-            image = utils.create_image_from_item(item)
+            image = utils.create_image_from_item(item, image_field)
             # Register the relation between the items
             utils.add_relation(item, image, "preview_image_link", metadata)
             # Return the new image
             yield image
-            yield item
-        else:
-            item.pop("image", None)
-            item.pop("image_caption", None)
-            yield item
+        yield cleanup_image_fields(item)

--- a/src/collective/transmute/utils/item.py
+++ b/src/collective/transmute/utils/item.py
@@ -66,7 +66,9 @@ def all_parents_for(id_: str) -> set[str]:
     return set(parents)
 
 
-def create_image_from_item(parent: t.PloneItem) -> t.PloneItem:
+def create_image_from_item(
+    parent: t.PloneItem, image_field: str = "image"
+) -> t.PloneItem:
     """
     Create a new image object to be placed inside the parent item.
 
@@ -74,6 +76,9 @@ def create_image_from_item(parent: t.PloneItem) -> t.PloneItem:
     ----------
     parent : PloneItem
         The parent item containing image data.
+    image_field : str
+        Name of the source field holding the image data, either ``image`` or
+        ``preview_image``. Defaults to ``image``.
 
     Returns
     -------
@@ -89,8 +94,9 @@ def create_image_from_item(parent: t.PloneItem) -> t.PloneItem:
         >>> img_item['@type']
         'Image'
     """
-    image: dict = parent.pop("image")
-    image_caption: str = parent.pop("image_caption", "")
+    image_field_caption = f"{image_field}_caption"
+    image: dict = parent.pop(image_field)
+    image_caption: str = parent.pop(image_field_caption, "")
     filename: str = image["filename"]
     parts = filename.rsplit(".", 1)
     name = parts[0]

--- a/tests/steps/test_step_image.py
+++ b/tests/steps/test_step_image.py
@@ -13,6 +13,15 @@ def base_news_item(load_json_resource) -> dict:
     return load_json_resource("image/news_item.json")
 
 
+@pytest.fixture
+def preview_image_news_item(base_news_item) -> dict:
+    """News item whose image data lives in ``preview_image`` instead of ``image``."""
+    item = dict(base_news_item)
+    item["preview_image"] = item.pop("image")
+    item["preview_image_caption"] = item.pop("image_caption")
+    return item
+
+
 class TestImageToPreviewLink:
     @pytest.fixture(autouse=True)
     def _setup(self, pipeline_state, patch_settings, transmute_settings):
@@ -117,3 +126,120 @@ class TestImageToPreviewLinkNoSettings:
             results.append(item)
         relations = metadata.relations
         assert len(relations) == total_relations
+
+
+class TestPreviewImageToPreviewLink:
+    @pytest.fixture(autouse=True)
+    def _setup(self, pipeline_state, patch_settings, transmute_settings):
+        self.pipeline_state = pipeline_state
+        self.settings = transmute_settings
+        self.func = image.process_image_to_preview_image_link
+
+    @pytest.mark.parametrize(
+        "idx,attr,expected",
+        [
+            [0, "@type", "Image"],
+            [0, "@id", "/Plone/noticias/2016/03/uma-noticia/imagem.jpg"],
+            [0, "id", "imagem.jpg"],
+            [0, "title", "imagem.jpg"],
+            [0, "image_caption", "An Image"],
+            [1, "@type", "News Item"],
+            [1, "@id", "/Plone/noticias/2016/03/uma-noticia"],
+        ],
+    )
+    async def test_create_image_item(
+        self, preview_image_news_item, idx: int, attr: str, expected: str
+    ):
+        results = []
+        async for item in self.func(
+            preview_image_news_item, self.pipeline_state, self.settings
+        ):
+            results.append(item)
+        assert results[idx][attr] == expected
+
+    @pytest.mark.parametrize(
+        "idx,attr,expected",
+        [
+            [0, "image", True],
+            [0, "image_caption", True],
+            [1, "preview_image", False],
+            [1, "preview_image_caption", False],
+        ],
+    )
+    async def test_attribute_exists(
+        self, preview_image_news_item, idx: int, attr: str, expected: bool
+    ):
+        results = []
+        async for item in self.func(
+            preview_image_news_item, self.pipeline_state, self.settings
+        ):
+            results.append(item)
+        assert (attr in results[idx]) is expected
+
+    async def test_relation_created(self, preview_image_news_item):
+        metadata = self.pipeline_state.metadata
+        total_relations = len(metadata.relations)
+        results = []
+        async for item in self.func(
+            preview_image_news_item, self.pipeline_state, self.settings
+        ):
+            results.append(item)
+        relations = metadata.relations
+        assert len(relations) == total_relations + 1
+        relation = relations[-1]
+        assert relation["from_attribute"] == "preview_image_link"
+        assert relation["from_uuid"] == results[1]["UID"]
+        assert relation["to_uuid"] == results[0]["UID"]
+
+    async def test_preview_image_takes_precedence(self, preview_image_news_item):
+        # Both fields present: preview_image must be the one converted.
+        preview_image_news_item["image"] = {
+            "content-type": "image/jpeg",
+            "data": "other-image",
+            "encoding": "base64",
+            "filename": "outro.jpg",
+        }
+        preview_image_news_item["image_caption"] = "Another Image"
+        results = []
+        async for item in self.func(
+            preview_image_news_item, self.pipeline_state, self.settings
+        ):
+            results.append(item)
+        # Created Image comes from preview_image (imagem.jpg), not image (outro.jpg).
+        assert results[0]["id"] == "imagem.jpg"
+        assert results[0]["image_caption"] == "An Image"
+        # Both source fields are stripped from the original item.
+        original = results[1]
+        assert "image" not in original
+        assert "image_caption" not in original
+        assert "preview_image" not in original
+        assert "preview_image_caption" not in original
+
+
+class TestCleanupImageFields:
+    def test_removes_all_image_fields(self):
+        item = {
+            "@type": "News Item",
+            "title": "Keep me",
+            "image": {"filename": "a.jpg"},
+            "image_caption": "caption",
+            "preview_image": {"filename": "b.jpg"},
+            "preview_image_caption": "another caption",
+        }
+        result = image.cleanup_image_fields(item)
+        assert "image" not in result
+        assert "image_caption" not in result
+        assert "preview_image" not in result
+        assert "preview_image_caption" not in result
+        assert result["title"] == "Keep me"
+
+    def test_returns_same_object(self):
+        item = {"@type": "News Item"}
+        assert image.cleanup_image_fields(item) is item
+
+    def test_noop_when_no_image_fields(self):
+        item = {"@type": "News Item", "title": "x"}
+        assert image.cleanup_image_fields(item) == {
+            "@type": "News Item",
+            "title": "x",
+        }

--- a/tests/utils/test_utils_item.py
+++ b/tests/utils/test_utils_item.py
@@ -86,6 +86,30 @@ def test_create_image_from_item(parent: t.PloneItem, expected: t.PloneItem):
     assert image.get("image_caption") == expected["image_caption"]
 
 
+def test_create_image_from_item_preview_image_field():
+    parent: t.PloneItem = {
+        "@id": "/parent",
+        "id": "parent",
+        "@type": "News Item",
+        "title": "Parent Item",
+        "preview_image": {
+            "filename": "sample-image.jpg",
+            "data": b"image-data",
+        },
+        "preview_image_caption": "An example image.",
+    }
+    image = item.create_image_from_item(parent, "preview_image")
+    assert image["@id"] == "/parent/sample-image.jpg"
+    assert image["@type"] == "Image"
+    # The created Image item always exposes ``image`` / ``image_caption`` keys,
+    # regardless of the source field.
+    assert image["image"]["filename"] == "sample-image.jpg"
+    assert image["image_caption"] == "An example image."
+    # Source fields are consumed from the parent.
+    assert "preview_image" not in parent
+    assert "preview_image_caption" not in parent
+
+
 class TestGenerateUid:
     def test_length(self):
         uid = item.generate_uid()


### PR DESCRIPTION
## Summary

`process_image_to_preview_image_link` now also supports the `preview_image` field, not just `image`. When an item carries a `preview_image`, it is converted into a `preview_image_link` relation exactly as `image` was. When **both** fields are present, `preview_image` takes precedence.

## Changes

- **`_types/plone.py`** — added `preview_image` and `preview_image_caption` to the `PloneItem` typed dict.
- **`steps/image.py`** — the step selects `preview_image` over `image` when present; extracted the field-removal logic into a reusable `cleanup_image_fields` helper (driven by a new `IMAGE_FIELDS` constant).
- **`utils/item.py`** — `create_image_from_item` is now parametrized on the source field (`image_field`, defaults to `"image"`).
- Docstrings updated to document the new parameter and behavior.

## Tests

- New coverage for the full `preview_image` path through the pipeline step, including the precedence rule when both fields exist.
- New unit tests for `cleanup_image_fields`.
- New coverage for `create_image_from_item(..., image_field="preview_image")`.
- Full suite: 287 passed; `ruff` clean.

Closes #70